### PR TITLE
Auto import for particular files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Class [`Config`](src/Config.php) with possibility to configure auto import classes.
+
+### Removed
+- Remove method [`Helper\NameNodeHelper::createNodeName()`](src/Helper/NameNodeHelper.php) because it did same as [`\PhpParser\Node\Name::prepareName()`](https://github.com/nikic/PHP-Parser/blob/v4.3.0/lib/PhpParser/Node/Name.php#L218).
+
+### Fixed
+- Fix convert constant to ast when auto import classes is enabled.

--- a/README.md
+++ b/README.md
@@ -855,6 +855,51 @@ return [
 ];
 ```
 
+## Config
+
+You can provide config object when create coder:
+```php
+use Crmplease\Coder\Coder;
+use Crmplease\Coder\Config;
+
+$config = new Config();
+$coder = Coder::create($config);
+```
+
+### Auto import classes
+
+By default auto import classes is disabled by [rector.yaml](rector.yaml). You can change default value or use mapping/callback for enable/disable auto import classes:
+
+```php
+use Crmplease\Coder\Config;
+
+$config = (new Config())
+    // use default value
+    ->setAutoImport(null)
+    // always auto import
+    ->setAutoImport(true)
+    // newer auto import
+    ->setAutoImport(false)
+    ->setAutoImport(
+        [
+            // auto import this file
+            '/path/to/file/with/enabled/auto/import/classes.php' => true,
+            // doesn't auto import this file
+            '/path/to/file/with/disabled/auto/import/classes.php' => false,
+            // use default value
+            '/path/to/file/with/defaul/auto/import/classes.php' => null,
+        ]
+    )
+    ->setAutoImport(
+        static function (string $file): ?bool {
+            // some logic
+            // if null is returned, then default value will be used
+            return $result;
+        }
+    )
+    ->setAutoImport([SomeClass::class, 'method']);
+```
+
 ## Internals
 
 If you want to auto import classes, then change `parameters.auto_import_names` to `true` in [rector.yaml](rector.yaml).

--- a/rector.yaml
+++ b/rector.yaml
@@ -5,6 +5,8 @@ services:
   Crmplease\Coder\Coder:
     public: true
   Crmplease\Coder\RectorRunner: null
+  Crmplease\Coder\Config:
+    public: true
 
   # rector helpers
   Crmplease\Coder\Helper\AddToArrayByKeyHelper: null

--- a/src/Coder.php
+++ b/src/Coder.php
@@ -45,13 +45,21 @@ class Coder
     private $changeClassParentRector;
 
     /**
+     * @param Config|null $config
+     *
      * @return static
      * @throws FileNotFoundException
      */
-    public static function create(): self
+    public static function create(?Config $config = null): self
     {
+        if (!$config) {
+            $config = new Config();
+        } else {
+            $config = clone $config;
+        }
         $containerConfigurator = new RectorContainerConfigurator();
         $container = $containerConfigurator->configureContainer();
+        $container->set(Config::class, $config);
         /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $container->get(__CLASS__);
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Crmplease\Coder;
+
+use function is_array;
+use function is_bool;
+use function is_callable;
+
+/**
+ * @author Mougrim <rinat@mougrim.ru>
+ */
+class Config
+{
+    protected $autoImport;
+
+    public function getAutoImport(): ?callable
+    {
+        if (!$this->autoImport) {
+            return null;
+        }
+        if (is_bool($this->autoImport)) {
+            $autoImport = $this->autoImport;
+            $this->autoImport = static function () use ($autoImport): bool {
+                return $autoImport;
+            };
+        } elseif (is_array($this->autoImport) && !is_callable($this->autoImport)) {
+            $autoImportMap = $this->autoImport;
+            $this->autoImport = static function(string $file) use ($autoImportMap): ?bool {
+                return $autoImportMap[$file] ?? null;
+            };
+        }
+        return $this->autoImport;
+    }
+
+    /**
+     * @param callable|array|bool|null $autoImport if null, the use default value from rector.yaml;
+     *        if true, the auto import will be always enabled;
+     *        if false, the auto import will be always disabled;
+     *        if array, they file name is used as key, value can be true/false/null;
+     *        if callable then it will receive file name as first argument and should return true/false/null.
+     *
+     * @return $this
+     */
+    public function setAutoImport($autoImport): self
+    {
+        $this->autoImport = $autoImport;
+        return $this;
+    }
+}

--- a/src/Helper/ConvertToAstHelper.php
+++ b/src/Helper/ConvertToAstHelper.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
@@ -115,9 +116,9 @@ class ConvertToAstHelper
     {
         if (strpos($constant, '::') !== false) {
             [$className, $constant] = explode('::', $constant);
-            return new ClassConstFetch($this->nameNodeHelper->createNodeName($className), new Identifier($constant));
+            return new ClassConstFetch(new FullyQualified(ltrim($className, '\\')), new Identifier($constant));
         }
 
-        return new ConstFetch($this->nameNodeHelper->createNodeName($constant));
+        return new ConstFetch(new Name($constant));
     }
 }

--- a/src/Helper/NameNodeHelper.php
+++ b/src/Helper/NameNodeHelper.php
@@ -22,12 +22,6 @@ class NameNodeHelper
         return $node->toString();
     }
 
-    public function createNodeName(string $name): Name
-    {
-        $parts = explode('\\', $name);
-        return new Name($parts);
-    }
-
     /**
      * @param Identifier|Name|NullableType|UnionType $node
      *

--- a/tests/Functional/ConfigTest.php
+++ b/tests/Functional/ConfigTest.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Crmplease\Coder\Functional;
+
+use Crmplease\Coder\Coder;
+use Crmplease\Coder\Config;
+use Crmplease\Coder\Constant;
+use Tests\Crmplease\Coder\fixtures\BazClass;
+use Tests\Crmplease\Coder\FunctionalTestCase;
+
+/**
+ * @author Mougrim <rinat@mougrim.ru>
+ */
+class ConfigTest extends FunctionalTestCase
+{
+    public function testAutoImportDisabled(): void
+    {
+        $fixture = 'autoImportDisabled';
+        $config = (new Config())
+            ->setAutoImport(false);
+        $coder = Coder::create($config)
+            ->setShowProgressBar(false);
+        $coder->addToFileReturnArrayByOrder(
+            $this->createFixtureFile($fixture),
+            [],
+            new Constant('\\' . BazClass::class . '::class'),
+        );
+        $this->assertFixture($fixture);
+    }
+
+    public function testAutoImportEnabled(): void
+    {
+        $fixture = 'autoImportEnabled';
+        $config = (new Config())
+            ->setAutoImport(true);
+        $coder = Coder::create($config)
+            ->setShowProgressBar(false);
+        $coder->addToFileReturnArrayByOrder(
+            $this->createFixtureFile($fixture),
+            [],
+            new Constant('\\' . BazClass::class . '::class'),
+        );
+        $this->assertFixture($fixture);
+    }
+
+    public function testAutoImportDisabledByArray(): void
+    {
+        $fixture = 'autoImportDisabled';
+        $config = (new Config())
+            ->setAutoImport(
+                [
+                    $this->getResultFixturePath($fixture) => false,
+                ]
+            );
+        $coder = Coder::create($config)
+            ->setShowProgressBar(false);
+        $coder->addToFileReturnArrayByOrder(
+            $this->createFixtureFile($fixture),
+            [],
+            new Constant('\\' . BazClass::class . '::class'),
+        );
+        $this->assertFixture($fixture);
+    }
+
+    public function testAutoImportEnabledByArray(): void
+    {
+        $fixture = 'autoImportEnabled';
+        $config = (new Config())
+            ->setAutoImport(
+                [
+                    $this->getResultFixturePath($fixture) => true,
+                ]
+            );
+        $coder = Coder::create($config)
+            ->setShowProgressBar(false);
+        $coder->addToFileReturnArrayByOrder(
+            $this->createFixtureFile($fixture),
+            [],
+            new Constant('\\' . BazClass::class . '::class'),
+        );
+        $this->assertFixture($fixture);
+    }
+
+    public function testAutoImportDisabledByCallback(): void
+    {
+        $fixture = 'autoImportDisabled';
+        $config = (new Config())
+            ->setAutoImport(
+                function (string $file) use ($fixture): bool {
+                    return $file !== $this->getResultFixturePath($fixture);
+                }
+            );
+        $coder = Coder::create($config)
+            ->setShowProgressBar(false);
+        $coder->addToFileReturnArrayByOrder(
+            $this->createFixtureFile($fixture),
+            [],
+            new Constant('\\' . BazClass::class . '::class'),
+        );
+        $this->assertFixture($fixture);
+    }
+
+    public function testAutoImportEnabledByCallback(): void
+    {
+        $fixture = 'autoImportEnabled';
+        $config = (new Config())
+            ->setAutoImport(
+                function (string $file) use ($fixture): bool {
+                    return $file === $this->getResultFixturePath($fixture);
+                }
+            );
+        $coder = Coder::create($config)
+            ->setShowProgressBar(false);
+        $coder->addToFileReturnArrayByOrder(
+            $this->createFixtureFile($fixture),
+            [],
+            new Constant('\\' . BazClass::class . '::class'),
+        );
+        $this->assertFixture($fixture);
+    }
+
+    public function testAutoImportDisabledByCallableArray(): void
+    {
+        $fixture = 'autoImportDisabled';
+        $config = (new Config())
+            ->setAutoImport([$this, 'autoImportDisabled']);
+        $coder = Coder::create($config)
+            ->setShowProgressBar(false);
+        $coder->addToFileReturnArrayByOrder(
+            $this->createFixtureFile($fixture),
+            [],
+            new Constant('\\' . BazClass::class . '::class'),
+        );
+        $this->assertFixture($fixture);
+    }
+
+    public function autoImportDisabled(): bool
+    {
+        return false;
+    }
+
+    public function testAutoImportEnabledByCallableArray(): void
+    {
+        $fixture = 'autoImportEnabled';
+        $config = (new Config())
+            ->setAutoImport([$this, 'autoImportEnabled']);
+        $coder = Coder::create($config)
+            ->setShowProgressBar(false);
+        $coder->addToFileReturnArrayByOrder(
+            $this->createFixtureFile($fixture),
+            [],
+            new Constant('\\' . BazClass::class . '::class'),
+        );
+        $this->assertFixture($fixture);
+    }
+
+    public function autoImportEnabled(): bool
+    {
+        return true;
+    }
+}

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -43,6 +43,11 @@ abstract class FunctionalTestCase extends TestCase
         ];
     }
 
+    protected function getResultFixturePath(string $name): string
+    {
+        return $this->getFixturePaths($name)['result'];
+    }
+
     protected function createFixtureFile(string $name): string
     {
         $paths = $this->getFixturePaths($name);

--- a/tests/fixtures/BazClass.php
+++ b/tests/fixtures/BazClass.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Crmplease\Coder\fixtures;
+
+/**
+ * @author Mougrim <rinat@mougrim.ru>
+ */
+class BazClass
+{
+    public const TEST = 'baz value';
+}

--- a/tests/fixtures/Config/autoImportDisabled.php
+++ b/tests/fixtures/Config/autoImportDisabled.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @author Mougrim <rinat@mougrim.ru>
+ */
+namespace Tests\Crmplease\Coder\fixtures\Config;
+
+use Tests\Crmplease\Coder\fixtures\FooClass;
+
+return [
+    FooClass::class,
+    \Tests\Crmplease\Coder\fixtures\BarClass::class,
+];

--- a/tests/fixtures/Config/autoImportDisabledExpected.php
+++ b/tests/fixtures/Config/autoImportDisabledExpected.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @author Mougrim <rinat@mougrim.ru>
+ */
+namespace Tests\Crmplease\Coder\fixtures\Config;
+
+use Tests\Crmplease\Coder\fixtures\FooClass;
+
+return [
+    FooClass::class,
+    \Tests\Crmplease\Coder\fixtures\BarClass::class,
+    \Tests\Crmplease\Coder\fixtures\BazClass::class,
+];

--- a/tests/fixtures/Config/autoImportEnabled.php
+++ b/tests/fixtures/Config/autoImportEnabled.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @author Mougrim <rinat@mougrim.ru>
+ */
+namespace Tests\Crmplease\Coder\fixtures\Config;
+
+use Tests\Crmplease\Coder\fixtures\FooClass;
+
+return [
+    FooClass::class,
+    \Tests\Crmplease\Coder\fixtures\BarClass::class,
+];

--- a/tests/fixtures/Config/autoImportEnabledExpected.php
+++ b/tests/fixtures/Config/autoImportEnabledExpected.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @author Mougrim <rinat@mougrim.ru>
+ */
+namespace Tests\Crmplease\Coder\fixtures\Config;
+
+use Tests\Crmplease\Coder\fixtures\BarClass;
+use Tests\Crmplease\Coder\fixtures\BazClass;
+use Tests\Crmplease\Coder\fixtures\FooClass;
+
+return [
+    FooClass::class,
+    BarClass::class,
+    BazClass::class,
+];


### PR DESCRIPTION
### Added
- Class [`Config`](src/Config.php) with possibility to configure auto import classes.

### Removed
- Remove method [`Helper\NameNodeHelper::createNodeName()`](src/Helper/NameNodeHelper.php) because it did same as [`\PhpParser\Node\Name::prepareName()`](https://github.com/nikic/PHP-Parser/blob/v4.3.0/lib/PhpParser/Node/Name.php#L218).

### Fixed
- Fix convert constant to ast when auto import classes is enabled.