### PR TITLE
Remove using global argv in RectorContainerConfigurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix convert constant to ast when auto import classes is enabled.
+- Remove using global argv in [`RectorContainerConfigurator`](src/RectorContainerConfigurator.php).

--- a/src/RectorContainerConfigurator.php
+++ b/src/RectorContainerConfigurator.php
@@ -38,7 +38,7 @@ class RectorContainerConfigurator
         $configs = [];
 
         // Detect configuration from --set
-        $input = new ArgvInput();
+        $input = new ArgvInput([]);
 
         $setConfig = $this->configResolver->resolveSetFromInputAndDirectory($input, Set::SET_DIRECTORY);
         if ($setConfig !== null) {


### PR DESCRIPTION
In `\Crmplease\Coder\RectorContainerConfigurator::provide()` we use ArgvInput, which uses global `$_SERVER['argv']`. As result we have side-effect - coder using command line option, but shouldn't use it.
Need don't use global variable.